### PR TITLE
Try setting cookie-session proxy to true

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -14,6 +14,7 @@ app.use(
   cookieSession({
     name: "session",
     keys: [process.env.cookieSessionKey],
+    secureProxy: true,
   })
 );
 console.log(process.env.cookieSessionKey);


### PR DESCRIPTION
I had to add this `secureProxy: true` to our cookie-session config, to get it to work on Heroku, as in [this stack overflow answer](https://stackoverflow.com/a/26225870/1638812)